### PR TITLE
Reformat .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,18 @@
-out/
+# IntelliJ ouput files
 .idea/
-.settings/
-.vscode
+out/
+*.iml
+
+# Maven output
 target/
+
+# Eclipse
+.settings/
 .classpath
 .project
+
+# VSCode
+.vscode/
+
+# Bot config file
 *.config
-*.config
-tjbot.config
-*.config
-*.config
-tjbot.config
-target/classes/
-target/maven-archiver/pom.properties
-target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
-target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
-target/maven-status/maven-compiler-plugin/testCompile/default-testCompile/inputFiles.lst
-target/original-tjbot.jar
-target/tjbot-1.0-SNAPSHOT-shaded.jar
-target/tjbot-1.0-SNAPSHOT.jar
-target/tjbot.jar


### PR DESCRIPTION
## Motivation
The `.gitignore` file contained duplicated or otherwise unneeded entries.

## Content
* Removed duplicates
* Consolidated entries